### PR TITLE
Represent `WCG` not as a non-sparse `Vec` of sparse vectors, but a sparse `BTreeMap` of sparse vectors

### DIFF
--- a/crypto/generalized-bulletproofs/Cargo.toml
+++ b/crypto/generalized-bulletproofs/Cargo.toml
@@ -24,7 +24,7 @@ std-shims = { version = "0.1.4", default-features = false }
 
 rand_core = { version = "0.6", default-features = false }
 
-zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive", "alloc"] }
 
 blake2 = { version = "0.10", default-features = false }
 

--- a/crypto/generalized-bulletproofs/src/lincomb.rs
+++ b/crypto/generalized-bulletproofs/src/lincomb.rs
@@ -111,11 +111,11 @@ impl<F: PrimeField> Add<&LinComb<F>> for LinComb<F> {
     self.WR.extend(&constraint.WR);
     self.WO.extend(&constraint.WO);
     for (i, sparse_vec) in &constraint.WCG {
-      if let Some(existing) = self.WCG.get_mut(i) {
-        existing.extend(sparse_vec);
-      } else {
-        self.WCG.insert(*i, sparse_vec.clone());
-      }
+      self
+        .WCG
+        .entry(*i)
+        .and_modify(|existing| existing.extend(sparse_vec))
+        .or_insert_with(|| sparse_vec.clone());
     }
     self.WV.extend(&constraint.WV);
     self.c += constraint.c;
@@ -133,12 +133,12 @@ impl<F: PrimeField> Sub<&LinComb<F>> for LinComb<F> {
     self.WR.extend(constraint.WR.iter().map(|(i, weight)| (*i, -*weight)));
     self.WO.extend(constraint.WO.iter().map(|(i, weight)| (*i, -*weight)));
     for (i, sparse_vec) in &constraint.WCG {
-      let sparse_vec = sparse_vec.iter().copied().map(|(j, value)| (j, -value));
-      if let Some(existing) = self.WCG.get_mut(i) {
-        existing.extend(sparse_vec);
-      } else {
-        self.WCG.insert(*i, sparse_vec.collect());
-      }
+      let mut sparse_vec = sparse_vec.iter().copied().map(|(j, value)| (j, -value));
+      self
+        .WCG
+        .entry(*i)
+        .and_modify(|existing| existing.extend(&mut sparse_vec))
+        .or_insert_with(|| sparse_vec.collect());
     }
     self.WV.extend(constraint.WV.iter().map(|(i, weight)| (*i, -*weight)));
     self.c -= constraint.c;
@@ -196,11 +196,11 @@ impl<F: PrimeField> LinComb<F> {
           dependent on the size of the IPA, hence why these _also_ update `highest_a_index`.
         */
         self.highest_a_index = self.highest_a_index.max(Some(j));
-        if let Some(values) = self.WCG.get_mut(&i) {
-          values.push((j, scalar));
-        } else {
-          self.WCG.insert(i, vec![(j, scalar)]);
-        }
+        self
+          .WCG
+          .entry(i)
+          .and_modify(|values| values.push((j, scalar)))
+          .or_insert_with(|| vec![(j, scalar)]);
       }
       Variable::V(i) => {
         self.highest_v_index = self.highest_v_index.max(Some(i));


### PR DESCRIPTION
Within the Monero protocol, the non-sparse `Vec` was spending hundreds of MB on empty vectors (just 16 bytes each) for commitments which had no terms constrained.

An earlier attempt tried a truly sparse vector, yet that invoked a O(n^2) algorithm to compute as the vector had to be iterated to find all entries within a specific vector, causing an O(n) invocation per commitment. This tripled the verification time.

This algorithm represents the memory in O(n log c) where n is the constrained terms and c is the amount of commitments which have constrained terms. While the amount of commitments is large, the amount constrained within a single `LinComb` should be small. Processing is an `O(log c)` lookup before the traditional `O(n)` iteration. Accordingly, this should have almost all of the memory savings with almost none of the performance cost.

cc @j-berman to provide exact performance numbers for the 1-in, 2-in, 4-in, 8-in, and 128-in cases (verification and time to verify) on https://github.com/monero-oxide/monero-oxide/pull/39. cc @boog900 to review this change to ensure it doesn't change the wires of the encoded program.